### PR TITLE
This is a fix for issue #40 (Chrome ADBlock plugin causing 404 not found error with Flexie)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 Cross-browser support for the [CSS3 Flexible Box Model](http://www.w3.org/TR/css3-flexbox/). Check out [The Playground](http://flexiejs.com/playground/) to see it in action.
-# Flexie v1.0.3 [![](http://stillmaintained.com/doctyper/flexie.png)](http://stillmaintained.com/doctyper/flexie)
+# Flexie v1.0.4 [![](http://stillmaintained.com/doctyper/flexie.png)](http://stillmaintained.com/doctyper/flexie)
+
+## Latest update
+
+* Forked & fixed error resulting from a conflict between adblockers and flexie. 
 
 ## Browser Support
 * IE 6-9

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Cross-browser support for the [CSS3 Flexible Box Model](http://www.w3.org/TR/css3-flexbox/). Check out [The Playground](http://flexiejs.com/playground/) to see it in action.
 # Flexie v1.0.4 [![](http://stillmaintained.com/doctyper/flexie.png)](http://stillmaintained.com/doctyper/flexie)
 
-## Latest update
+## Latest updates
 
 * Forked & fixed error resulting from a conflict between adblockers and flexie. 
 

--- a/src/flexie.js
+++ b/src/flexie.js
@@ -1329,7 +1329,7 @@ var Flexie = (function (win, doc) {
 			for (i = 0, j = stylesheets.length; i < j; i++) {
 				stylesheet = stylesheets[i];
 
-				if (stylesheet) {
+				if (stylesheet && stylesheet.href !== 'data:text/css,') {
 					url = resolveUrl(stylesheet.href, baseUrl);
 
 					if (url) {


### PR DESCRIPTION
Issue #40: https://github.com/doctyper/flexie/issues/40

Contains fix for 'GET http://domain.com/data:text/css, 404 (Not Found)' error generated by Flexie. This is caused by the ADBlock plugin in Chrome; it inserts 'data:text/css' into the code, which Flexie sees and attempts to parse, resulting in an error. Fix simply tells the code to ignore 'data:text/css'. 
