### PR TITLE
Fix for initializing Flexie with JS for nested layouts in IE 9 and lower

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -103,6 +103,6 @@
 		<!-- <script src="https://ajax.googleapis.com/ajax/libs/dojo/1.5/dojo/dojo.xd.js" type="text/javascript"></script> -->
 		
 		<!-- Flexie -->
-		<script src="/src/flexie.js" type="text/javascript"></script>
+		<script src="../src/flexie.js" type="text/javascript"></script>
 	</body>
 </html>

--- a/src/flexie.js
+++ b/src/flexie.js
@@ -2030,7 +2030,7 @@ var Flexie = (function (win, doc) {
 	FLX.version = "1.0.3";
 
 	// Load when the DOM is ready
-	attachLoadMethod(FLX.init);
+	//attachLoadMethod(FLX.init);
 	
 	return FLX;
 }(this, document));

--- a/src/flexie.js
+++ b/src/flexie.js
@@ -1067,14 +1067,14 @@ var Flexie = (function (win, doc) {
 		    isNested;
 		
 		while (parent.FLX_DOM_ID) {
-			obj = FLEX_BOXES[parent.FLX_DOM_ID];
-			matrix = createMatchMatrix(obj.children, sanitizeChildren(parent, parent.childNodes), NULL);
-			
-			totalFlex += matrix.total;
-			isNested = TRUE;
-			
-			parent = parent.parentNode;
-		}
+            if (FLEX_BOXES[parent.FLX_DOM_ID]) {
+                obj = FLEX_BOXES[parent.FLX_DOM_ID];
+                matrix = createMatchMatrix(obj.children, sanitizeChildren(parent, parent.childNodes), NULL);
+                totalFlex += matrix.total;
+                isNested = TRUE;
+            }
+            parent = parent.parentNode;
+        }
 		
 		return {
 			nested : isNested,
@@ -1895,7 +1895,7 @@ var Flexie = (function (win, doc) {
 			while (parent) {
 				flex = FLEX_BOXES[parent.FLX_DOM_ID];
 				
-				if (flex) {
+				if (flex && flex.nodes) {
 					cleanPositioningProperties(flex.nodes);
 					self.setup(flex.target, flex.nodes, flex);
 				}

--- a/src/flexie.js
+++ b/src/flexie.js
@@ -1548,11 +1548,13 @@ var Flexie = (function (win, doc) {
 							x = flexers[key][k];
 							max = NULL;
 							
-							for (m = 0, n = x.properties.length; m < n; m++) {
-								rule = x.properties[m];
+							if (x.properties) {
+								for (m = 0, n = x.properties.length; m < n; m++) {
+									rule = x.properties[m];
 
-								if ((RESTRICTIVE_PROPERTIES).test(rule.property)) {
-									max = parseFloat(rule.value);
+									if ((RESTRICTIVE_PROPERTIES).test(rule.property)) {
+										max = parseFloat(rule.value);
+									}
 								}
 							}
 							

--- a/test/css/nested-grid-js.css
+++ b/test/css/nested-grid-js.css
@@ -1,0 +1,33 @@
+/* set up stuff: */
+body, html {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  font: normal 13px/16px "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+#box-wrap {
+  margin: 0 auto;
+  width: 70%;
+  height: 99%;
+  border: 1px solid #8ec1da;
+  background: #d9ecf5;
+}
+
+#box-wrap-inner div {
+  margin: 10px;
+  background: #f8f8f8;
+  border: 1px solid #8ec1da;
+  text-align: center;
+  line-height: 50px;
+}
+
+/* Sizing of flex-boxes: */
+#box-wrap-inner {
+  height: 100%;
+}
+
+#menu {
+  width: 200px;
+}

--- a/test/css/nested-grid.css
+++ b/test/css/nested-grid.css
@@ -1,0 +1,48 @@
+/* set up stuff: */
+body, html {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  margin: 0;
+  font: normal 13px/16px "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+
+#box-wrap {
+  margin: 0 auto;
+  width: 70%;
+  height: 99%;
+  border: 1px solid #8ec1da;
+  background: #d9ecf5;
+}
+
+#box-wrap-inner div {
+  margin: 10px;
+  background: #f8f8f8;
+  border: 1px solid #8ec1da;
+  text-align: center;
+  line-height: 50px;
+}
+
+/* Sizing of flex-boxes: */
+#box-wrap-inner {
+  height: 100%;
+}
+
+#menu {
+  width: 200px;
+}
+
+/* Flexie specific styles: */
+#box-wrap-inner {
+  display: box;
+  box-orient: vertical;
+}
+
+#box-2 {
+  box-flex: 1;
+  display: box;
+}
+
+#main {
+  box-flex: 1;
+}

--- a/test/nested-grid-js.html
+++ b/test/nested-grid-js.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Flexie grid</title>
+    <!--[if lte IE 8]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+    <link rel="stylesheet" href="css/nested-grid-js.css" type="text/css" />
+  </head>
+  <body>
+    <div id="box-wrap">
+      <div id="box-wrap-inner">
+        <div id="box-1">Box 1</div>
+        <div id="box-2">
+          <div id="menu">menu</div>
+          <div id="main">main</div>
+        </div>
+        <div id="box-3">Box 3</div>
+      </div>
+    </div>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.3/jquery.min.js" type="text/javascript"></script>
+    <script src="../src/flexie.js" type="text/javascript"></script>
+    <script>
+window.setTimeout(function () {
+  var box = new Flexie.box({
+      target : document.getElementById("box-wrap-inner"),
+      orient : "vertical",
+      flexMatrix : [0, 1, 0]
+  });
+
+  var inner = new Flexie.box({
+      target : document.getElementById("box-2"),
+      flexMatrix : [0, 1]
+  });
+}, 1000);
+    </script>
+  </body>
+</html>

--- a/test/nested-grid.html
+++ b/test/nested-grid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Flexie grid</title>
+    <!--[if lte IE 8]><script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script><![endif]-->
+    <link rel="stylesheet" href="css/nested-grid.css" type="text/css" />
+  </head>
+  <body>
+    <div id="box-wrap">
+      <div id="box-wrap-inner">
+        <div id="box-1">Box 1</div>
+        <div id="box-2">
+          <div id="menu">menu</div>
+          <div id="main">main</div>
+        </div>
+        <div id="box-3">Box 3</div>
+      </div>
+    </div>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.3/jquery.min.js" type="text/javascript"></script>
+    <script src="../src/flexie.js" type="text/javascript"></script>
+  </body>
+</html>


### PR DESCRIPTION
This also depends on the fix by @harrylove. The tests contain one example nesting a horizontal layout in a vertical one initialized with CSS and one version set up with JS. The tests only contain flexbox code relevant for Flexie, and will not flex in browsers where flexbox is natively supported.
