### PR TITLE
Fixed IE6 hanging

### DIFF
--- a/src/flexie.js
+++ b/src/flexie.js
@@ -1387,7 +1387,7 @@ var Flexie = (function (win, doc) {
 								target.style.zoom = "1";
 
 								if (BROWSER.IE === 6) {
-									stylesheet.addRule(selector.replace(/\>|\+|\~/g, ""), paddingFix + "zoom:1;", 0);
+									stylesheet.cssText += selector.replace(/\>|\+|\~/g, "") + "{" + paddingFix + "zoom:1;}";
 								} else if (BROWSER.IE === 7) {
 									stylesheet.addRule(selector, paddingFix + "display:inline-block;", 0);
 								}


### PR DESCRIPTION
stylesheet.addRule hangs in IE6 when the an unsupported selector is used. Appending to cssText works around this issue.
